### PR TITLE
✨ [Feat] 초기 세팅 및 로그인 기능

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,20 @@
       "Bash(docker info:*)",
       "Bash(docker ps:*)",
       "Bash(netstat:*)",
-      "Bash(findstr:*)"
+      "Bash(findstr:*)",
+      "Bash(./gradlew clean build:*)",
+      "Bash(./gradlew build:*)",
+      "Bash(./gradlew compileJava:*)",
+      "Bash(docker-compose logs:*)",
+      "Bash(docker-compose down:*)",
+      "Bash(docker-compose build:*)",
+      "Bash(docker-compose up:*)",
+      "Bash(curl:*)",
+      "Bash(docker run:*)",
+      "Bash(python:*)",
+      "Bash(docker logs:*)",
+      "Bash(docker exec:*)",
+      "Bash(docker restart:*)"
     ]
   }
 }

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -58,9 +58,12 @@ jobs:
           container-name: ${{ env.CONTAINER_NAME }}
           image: ${{ steps.build-image.outputs.image }}
           environment-variables: |
+            SPRING_PROFILES_ACTIVE=prod
             DB_URL=${{ secrets.DB_URL }}
             DB_USERNAME=${{ secrets.DB_USERNAME }}
             DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+            JWT_SECRET=${{ secrets.JWT_SECRET }}
+            CORS_ORIGINS=${{ secrets.CORS_ORIGINS }}
 
       - name: Deploy to Amazon ECS
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -64,6 +64,9 @@ jobs:
             DB_PASSWORD=${{ secrets.DB_PASSWORD }}
             JWT_SECRET=${{ secrets.JWT_SECRET }}
             CORS_ORIGINS=${{ secrets.CORS_ORIGINS }}
+            SPRING_DATA_REDIS_HOST=${{ secrets.REDIS_HOST }}
+            SPRING_DATA_REDIS_PORT=${{ secrets.REDIS_PORT }}
+            SPRING_DATA_REDIS_SSL=${{ secrets.REDIS_SSL }}
 
       - name: Deploy to Amazon ECS
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ out/
 .env.local
 .env.*
 !.env.example
+application-local.yaml
 
 ### Docker ###
 docker-compose.override.yml
@@ -54,3 +55,6 @@ replay_pid*
 .DS_Store
 Thumbs.db
 Desktop.ini
+
+### etc ###
+CLAUDE.md

--- a/build.gradle
+++ b/build.gradle
@@ -28,13 +28,22 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,9 @@ services:
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      TZ: Asia/Seoul
     ports:
-      - "3307:3306"
+      - "3308:3306"
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       interval: 5s
@@ -18,6 +19,17 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
 
+  redis:
+    image: redis:7-alpine
+    container_name: aegis-redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
   app:
     build: .
     container_name: aegis-backend
@@ -25,10 +37,17 @@ services:
       DB_URL: jdbc:mysql://mysql:3306/${MYSQL_DATABASE}?useSSL=false&allowPublicKeyRetrieval=true
       DB_USERNAME: ${MYSQL_USER}
       DB_PASSWORD: ${MYSQL_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
+      CORS_ORIGINS: ${CORS_ORIGINS}
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: 6379
+      TZ: Asia/Seoul
     ports:
       - "8080:8080"
     depends_on:
       mysql:
+        condition: service_healthy
+      redis:
         condition: service_healthy
 
 volumes:

--- a/docs/AWS_DEPLOYMENT_GUIDE.md
+++ b/docs/AWS_DEPLOYMENT_GUIDE.md
@@ -1,4 +1,4 @@
-# AWS 배포 가이드 - Aegis Backend (완전판)
+# AWS 배포 가이드 - Aegis Backend
 
 ## 전체 아키텍처
 
@@ -11,10 +11,18 @@
 ┌─────────────────────────────────────────────────────────────┐
 │                         AWS VPC                              │
 │  ┌──────────────────┐     ┌───────────────────────────┐     │
-│  │   RDS MySQL      │ ←── │  EC2 (ECS Container)      │     │
-│  │   (Private)      │     │  ├─ Spring Boot (:8080)   │     │
-│  │   aegis-mysql    │     │  └─ FastAPI (:8000) 예정  │     │
-│  └──────────────────┘     └───────────────────────────┘     │
+│  │ ElastiCache      │ ←── │  EC2 (ECS Container)      │     │
+│  │ Redis (Private)  │     │  ├─ Spring Boot (:8080)   │     │
+│  │ aegis-redis      │     │  └─ FastAPI (:8000) 예정  │     │
+│  │ :6379            │     └─────────────┬─────────────┘     │
+│  └──────────────────┘                   │                   │
+│                                         │                   │
+│  ┌──────────────────┐                   │                   │
+│  │   RDS MySQL      │ ←─────────────────┘                   │
+│  │   (Private)      │                                       │
+│  │   aegis-mysql    │                                       │
+│  │   :3306          │                                       │
+│  └──────────────────┘                                       │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -573,65 +581,223 @@ curl http://[EC2_PUBLIC_IP]:8080/actuator/health
 
 ---
 
-# PART 3: 트러블슈팅
+# PART 3: ElastiCache Redis 설정
 
 ---
 
-## ECS 서비스가 계속 롤백되는 경우
+## 12. ElastiCache Redis 보안 그룹 생성
 
-### 원인 1: 헬스체크 Start period 부족
-**확인**: 태스크 정의 → 컨테이너 → HealthCheck → Start period가 120초인지 확인
-**해결**: 태스크 정의 새 개정 생성하여 Start period를 120 이상으로 설정
+### 12.1 보안 그룹 페이지 이동
+1. 상단 검색창 클릭 → `VPC` 입력 → **VPC** 클릭
+2. 좌측 메뉴 **보안** 섹션 → **보안 그룹** 클릭
+3. 우측 상단 주황색 **보안 그룹 생성** 버튼 클릭
 
-### 원인 2: RDS 연결 실패
-**확인**:
-1. ECS → 클러스터 → 서비스 → 태스크 탭 → 중지된 태스크 클릭
-2. **로그** 탭에서 `Connection refused` 또는 `Communications link failure` 오류 확인
+### 12.2 Redis용 보안 그룹 생성
 
-**해결**:
-1. RDS와 EC2가 같은 VPC인지 확인
-2. RDS 보안 그룹에서 `10.0.0.0/16` 인바운드 허용 확인
-3. DB_URL, DB_USERNAME, DB_PASSWORD 오타 확인
+**기본 세부 정보** 섹션:
+- **보안 그룹 이름**: `aegis-redis-sg`
+- **설명**: `ElastiCache Redis`
+- **VPC**: 드롭다운에서 **aegis-vpc** 선택
 
-### 원인 3: ECR 이미지 pull 실패
-**확인**: 태스크 로그에서 `CannotPullContainerError` 오류
+**인바운드 규칙** 섹션:
+1. **규칙 추가** 버튼 클릭
+2. 첫 번째 규칙:
+   - **유형**: 드롭다운에서 `사용자 지정 TCP` 선택
+   - **포트 범위**: `6379`
+   - **소스**: 드롭다운에서 `사용자 지정` 선택 → `10.0.0.0/16` 입력
 
-**해결**:
-1. IAM → 역할 → `ecsTaskExecutionRole` 클릭
-2. `AmazonECSTaskExecutionRolePolicy` 정책이 연결되어 있는지 확인
-3. 없으면 **정책 연결** → 검색 → 연결
+**아웃바운드 규칙** 섹션:
+- 기본값 유지 (모든 트래픽 허용)
 
-### 원인 4: 포트 충돌
-**확인**: 태스크 로그에서 `Bind for 0.0.0.0:8080 failed: port is already allocated`
+3. 맨 아래 주황색 **보안 그룹 생성** 버튼 클릭
 
-**해결**:
-1. 기존 태스크가 완전히 중지될 때까지 대기
-2. 서비스 → **태스크** 탭에서 `RUNNING` 태스크가 1개인지 확인
+> **메모**: Redis 보안 그룹 ID `sg-________________`
 
 ---
 
-## GitHub Actions가 실패하는 경우
+## 13. ElastiCache 서브넷 그룹 생성
 
-### 원인 1: AWS 자격 증명 오류
-**메시지**: `Unable to locate credentials`
+### 13.1 ElastiCache 페이지 이동
+1. 상단 검색창 클릭 → `ElastiCache` 입력 → **ElastiCache** 클릭
+2. 좌측 메뉴 **서브넷 그룹** 클릭
+3. 우측 상단 주황색 **서브넷 그룹 생성** 버튼 클릭
 
-**해결**:
-1. GitHub Secrets에서 `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` 확인
-2. 값 복사 시 앞뒤 공백이 없는지 확인
+### 13.2 설정 입력
 
-### 원인 2: 태스크 정의를 찾을 수 없음
-**메시지**: `Unable to describe task definition`
+**서브넷 그룹 세부 정보** 섹션:
+- **이름**: `aegis-redis-subnet-group`
+- **설명**: `Redis subnet group for Aegis`
+- **VPC ID**: 드롭다운에서 **aegis-vpc** 선택
 
-**해결**:
-1. AWS 콘솔에서 태스크 정의 `aegis-backend-task`가 있는지 확인
-2. 없으면 7단계부터 다시 진행
+**서브넷 선택** 섹션:
+1. **가용 영역** 드롭다운에서 `ap-northeast-2a` 선택
+2. **서브넷 ID** 드롭다운에서 **프라이빗 서브넷** 선택 (`aegis-subnet-private1-ap-northeast-2a`)
+3. **서브넷 추가** 버튼 클릭
+4. 다시 **가용 영역** 드롭다운에서 `ap-northeast-2b` 선택
+5. **서브넷 ID** 드롭다운에서 **프라이빗 서브넷** 선택 (`aegis-subnet-private2-ap-northeast-2b`)
+6. **서브넷 추가** 버튼 클릭
 
-### 원인 3: ECR 푸시 권한 없음
-**메시지**: `no basic auth credentials`
+> **참고**: Redis는 VPC 내부에서만 접근하므로 프라이빗 서브넷에 배치합니다.
 
-**해결**:
-1. IAM 사용자에 `AmazonEC2ContainerRegistryFullAccess` 정책 확인
-2. 없으면 추가
+3. 맨 아래 주황색 **생성** 버튼 클릭
+
+---
+
+## 14. ElastiCache 캐시 생성
+
+### 14.1 ElastiCache 캐시 생성 페이지 이동
+1. 좌측 메뉴 **캐시** 클릭
+2. 우측 상단 주황색 **캐시 생성** 버튼 클릭
+
+### 14.2 배포 옵션 및 생성 방법 선택
+
+**배포 옵션** 섹션:
+- [x] **노드 기반 캐시** 선택
+
+**생성 방법** 섹션:
+- [x] **간편한 생성** 선택
+
+### 14.3 구성 선택
+
+**구성** 섹션:
+- [x] **데모** 선택
+  - `cache.t4g.micro` (0.5 GiB 메모리)
+  - 비용 절약을 위해 가장 작은 노드 선택
+
+### 14.4 클러스터 정보
+
+**이름** 섹션:
+- **이름**: `aegis-redis`
+
+**설명** 섹션:
+- 기본값 유지 또는 원하는 설명 입력
+
+### 14.5 연결 설정
+
+**네트워크 유형** 섹션:
+- [x] **IPv4** 선택
+
+**서브넷 그룹** 섹션:
+- **기존 서브넷 그룹 선택** 선택
+- 드롭다운에서 `aegis-redis-subnet-group` 선택
+
+### 14.6 생성
+
+1. 맨 아래 주황색 **생성** 버튼 클릭
+2. **5-10분 대기** (상태가 "생성 중" → "사용 가능"으로 변경될 때까지)
+
+### 14.7 보안 그룹 수정
+
+> 간편한 생성은 default 보안 그룹을 사용합니다. 생성 후 수정이 필요합니다.
+
+1. **캐시** 목록에서 `aegis-redis` 클릭
+2. 우측 상단 **수정** 버튼 클릭
+3. **보안 그룹** 섹션에서:
+   - **default** 보안 그룹 제거 (X 클릭)
+   - 드롭다운에서 `aegis-redis-sg` 선택
+4. **변경 사항 저장** 버튼 클릭
+
+### 14.8 엔드포인트 확인
+1. **캐시** 목록에서 `aegis-redis` 클릭
+2. **캐시 세부 정보** 에서 **구성 엔드포인트** 확인
+3. 엔드포인트 복사 (포트 `:6379` 제외)
+
+> **메모**: 엔드포인트 `clustercfg.aegis-redis.xxxxxx.apn2.cache.amazonaws.com`
+
+> **참고**: 간편한 생성은 클러스터 모드가 활성화되므로 구성 엔드포인트를 사용합니다
+
+---
+
+## 15. ECS 태스크 정의에 Redis 환경 변수 추가
+
+### 15.1 태스크 정의 새 개정 생성
+1. ECS 콘솔 → 좌측 메뉴 **태스크 정의** 클릭
+2. `aegis-backend-task` 클릭
+3. 최신 개정 선택 → **새 개정 생성** 버튼 클릭
+
+### 15.2 환경 변수 추가
+
+**컨테이너 - 1** 섹션에서 `aegis-backend` 클릭
+
+**환경 변수** 섹션에 2개 추가:
+
+| 키 | 값 유형 | 값 |
+|----|---------|-----|
+| `REDIS_HOST` | 값 | `aegis-redis.xxxxxx.0001.apn2.cache.amazonaws.com` |
+| `REDIS_PORT` | 값 | `6379` |
+
+3. 맨 아래 주황색 **생성** 버튼 클릭
+
+### 15.3 ECS 서비스 업데이트
+1. ECS 콘솔 → **클러스터** → `aegis-cluster` 클릭
+2. **서비스** 탭에서 `aegis-backend-service` 체크
+3. **업데이트** 버튼 클릭
+4. **태스크 정의 개정**에서 최신 개정 선택
+5. **서비스 업데이트** 버튼 클릭
+
+---
+
+## 16. GitHub Secrets 추가
+
+### 16.1 GitHub Secrets 페이지 이동
+1. GitHub에서 `SPB_SERVER` 리포지토리 → **Settings** 탭
+2. 좌측 메뉴 **Secrets and variables** → **Actions** 클릭
+3. **New repository secret** 버튼 클릭
+
+### 16.2 Secrets 추가 (3개)
+
+**Secret 1:**
+- **Name**: `REDIS_HOST`
+- **Secret**: Redis 엔드포인트 붙여넣기 (예: `aegis-redis.xxxxxx.0001.apn2.cache.amazonaws.com`)
+- **Add secret** 클릭
+
+**Secret 2:**
+- **Name**: `REDIS_PORT`
+- **Secret**: `6379`
+- **Add secret** 클릭
+
+**Secret 3:**
+- **Name**: `JWT_SECRET`
+- **Secret**: 256비트 이상의 시크릿 키 입력 (예: 64자 이상의 랜덤 문자열)
+- **Add secret** 클릭
+
+> JWT 시크릿 생성 예시: `openssl rand -base64 64` 명령어로 생성
+
+### 16.3 확인
+총 8개의 Secrets가 등록되었는지 확인:
+- AWS_ACCESS_KEY_ID
+- AWS_SECRET_ACCESS_KEY
+- DB_URL
+- DB_USERNAME
+- DB_PASSWORD
+- REDIS_HOST
+- REDIS_PORT
+- JWT_SECRET
+
+---
+
+## 17. GitHub Actions 워크플로우 수정
+
+### 17.1 `.github/workflows/cicd.yml` 수정
+
+태스크 정의 업데이트 부분에 Redis 환경 변수 추가:
+
+```yaml
+- name: Update ECS task definition
+  id: task-def
+  uses: aws-actions/amazon-ecs-render-task-definition@v1
+  with:
+    task-definition: ${{ steps.download-task-def.outputs.task-definition }}
+    container-name: aegis-backend
+    image: ${{ steps.build-image.outputs.image }}
+    environment-variables: |
+      DB_URL=${{ secrets.DB_URL }}
+      DB_USERNAME=${{ secrets.DB_USERNAME }}
+      DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+      REDIS_HOST=${{ secrets.REDIS_HOST }}
+      REDIS_PORT=${{ secrets.REDIS_PORT }}
+      JWT_SECRET=${{ secrets.JWT_SECRET }}
+```
 
 ---
 
@@ -653,6 +819,254 @@ curl http://[EC2_PUBLIC_IP]:8080/actuator/health
 
 ---
 
+# PART 5: Route 53 도메인 연결
+
+---
+
+## 18. Elastic IP 할당 (필수 선행)
+
+> **중요**: EC2 퍼블릭 IP는 인스턴스가 재시작되면 바뀝니다. 도메인을 연결하려면 고정 IP(Elastic IP)가 필요합니다.
+
+### 18.1 Elastic IP 페이지 이동
+1. 상단 검색창 클릭 → `EC2` 입력 → **EC2** 클릭
+2. 좌측 메뉴 스크롤 → **네트워크 및 보안** 섹션 → **탄력적 IP** 클릭
+3. 우측 상단 주황색 **탄력적 IP 주소 할당** 버튼 클릭
+
+### 18.2 설정 입력
+
+**네트워크 경계 그룹** 섹션:
+- **리전**: `ap-northeast-2` (기본값)
+
+**퍼블릭 IPv4 주소 풀** 섹션:
+- [x] **Amazon의 IPv4 주소 풀** 선택 (기본값)
+
+**태그** 섹션:
+- **키**: `Name`
+- **값**: `aegis-eip`
+
+3. 맨 아래 주황색 **할당** 버튼 클릭
+
+### 18.3 EC2 인스턴스에 연결
+1. 방금 생성된 Elastic IP를 선택 (체크박스)
+2. 우측 상단 **작업** 드롭다운 → **탄력적 IP 주소 연결** 클릭
+3. **리소스 유형**: `인스턴스` 선택
+4. **인스턴스**: 드롭다운에서 ECS EC2 인스턴스 선택 (`ECS Instance - aegis-cluster`)
+5. **프라이빗 IP 주소**: 자동 선택됨 (기본값)
+6. 주황색 **연결** 버튼 클릭
+
+> **메모**: Elastic IP `________________`
+> **주의**: 이제부터 이 IP가 EC2의 고정 퍼블릭 IP입니다. 기존 퍼블릭 IP는 무효화됩니다.
+
+---
+
+## 19. 도메인 등록 (Route 53)
+
+> 이미 가지고 있는 도메인이 있으면 19단계를 건너뛰고 20단계로 이동하세요.
+
+### 19.1 Route 53 페이지 이동
+1. 상단 검색창 클릭 → `Route 53` 입력 → **Route 53** 클릭
+2. 좌측 메뉴 **등록된 도메인** 클릭
+3. 주황색 **도메인 등록** 버튼 클릭
+
+### 19.2 도메인 검색
+
+**도메인 이름 선택** 섹션:
+1. 검색창에 원하는 도메인 입력 (예시):
+   - `aegis-fire.com`
+   - `aegis-119.com`
+   - `aegis-rescue.com`
+   - `aegis-api.com`
+2. **검색** 버튼 클릭
+3. 사용 가능한 도메인 확인 (✅ 표시)
+4. 원하는 도메인 옆 **선택** 버튼 클릭
+5. **체크아웃으로 진행** 버튼 클릭
+
+> **참고**: `.com` 도메인은 연간 약 $13 (약 17,000원), `.net`은 약 $11입니다.
+> `.click`, `.link` 등은 $3~5로 저렴합니다.
+
+### 19.3 연락처 정보 입력
+
+**등록자 연락처** 섹션:
+- 이름, 이메일, 전화번호 등 입력 (실제 정보)
+- **개인 정보 보호**: `활성화` 선택 (WHOIS에 개인정보 숨김)
+
+### 19.4 결제 및 등록
+1. 약관 동의 체크
+2. **주문 완료** 버튼 클릭
+3. 이메일 인증 메일 확인 → 링크 클릭
+4. **등록 완료까지 최대 10~30분** 소요
+
+> **메모**: 등록한 도메인 `________________`
+
+---
+
+## 20. 호스팅 영역 생성
+
+> 19단계에서 Route 53으로 도메인을 등록했다면, 호스팅 영역이 **자동 생성**됩니다.
+> 이 경우 20단계를 건너뛰고 21단계로 이동하세요.
+>
+> 외부에서 구매한 도메인(가비아, Namecheap 등)을 사용하는 경우에만 이 단계가 필요합니다.
+
+### 20.1 호스팅 영역 페이지 이동
+1. Route 53 콘솔 → 좌측 메뉴 **호스팅 영역** 클릭
+2. 주황색 **호스팅 영역 생성** 버튼 클릭
+
+### 20.2 설정 입력
+
+**도메인 이름** 섹션:
+- 구매한 도메인 입력 (예: `aegis-fire.com`)
+
+**설명** 섹션:
+- `Aegis project` (선택사항)
+
+**유형** 섹션:
+- [x] **퍼블릭 호스팅 영역** 선택
+
+3. 주황색 **호스팅 영역 생성** 버튼 클릭
+
+### 20.3 네임서버 설정 (외부 도메인인 경우만)
+
+> Route 53에서 도메인을 등록한 경우 이 단계는 불필요합니다.
+
+1. 생성된 호스팅 영역 클릭
+2. **NS** 레코드의 값 4개 확인 (예시):
+   ```
+   ns-1234.awsdns-12.org.
+   ns-567.awsdns-34.net.
+   ns-890.awsdns-56.co.uk.
+   ns-12.awsdns-78.com.
+   ```
+3. 도메인 구매한 사이트(가비아 등)에 로그인
+4. 도메인 관리 → 네임서버 설정
+5. 위 4개의 네임서버를 등록
+6. **네임서버 전파까지 최대 24~48시간** 소요 (보통 1~2시간)
+
+---
+
+## 21. DNS 레코드 생성 (도메인 → EC2 연결)
+
+### 21.1 호스팅 영역 이동
+1. Route 53 콘솔 → 좌측 메뉴 **호스팅 영역** 클릭
+2. 도메인 이름 클릭 (예: `aegis-fire.com`)
+
+### 21.2 API 서브도메인 레코드 생성
+
+1. 주황색 **레코드 생성** 버튼 클릭
+
+**레코드 이름** 섹션:
+- 입력창에 `api` 입력 → 결과: `api.aegis-fire.com`
+
+**레코드 유형** 섹션:
+- **A** 선택 (IPv4 주소로 라우팅)
+
+**값** 섹션:
+- 18단계에서 할당한 **Elastic IP** 입력 (예: `3.35.xxx.xxx`)
+
+**TTL(초)** 섹션:
+- `300` (기본값)
+
+**라우팅 정책** 섹션:
+- **단순 라우팅** 선택 (기본값)
+
+2. 주황색 **레코드 생성** 버튼 클릭
+
+### 21.3 (선택) 루트 도메인 레코드 생성
+
+> API와 프론트엔드를 같은 도메인에서 운영하려면 루트 도메인도 설정합니다.
+
+1. 다시 **레코드 생성** 버튼 클릭
+2. **레코드 이름**: 비워두기 (루트 도메인 = `aegis-fire.com`)
+3. **레코드 유형**: `A`
+4. **값**: 같은 Elastic IP 입력
+5. **레코드 생성** 클릭
+
+### 21.4 전파 확인
+
+**DNS 전파는 보통 1~5분** 걸립니다. 터미널에서 확인:
+
+```bash
+# DNS 조회 확인
+nslookup api.aegis-fire.com
+
+# 실제 접속 테스트
+curl http://api.aegis-fire.com:8080/actuator/health
+```
+
+> `{"status":"UP"}` 응답이 오면 성공!
+
+---
+
+## 22. 최종 접속 URL 정리
+
+도메인 연결 후 접속 가능한 URL:
+
+| 용도 | URL |
+|------|-----|
+| **헬스체크** | `http://api.aegis-fire.com:8080/actuator/health` |
+| **Swagger UI** | `http://api.aegis-fire.com:8080/swagger-ui.html` |
+| **API 베이스** | `http://api.aegis-fire.com:8080/api/` |
+
+---
+
+## 23. (선택) HTTPS 적용 - ACM + ALB
+
+> 현재 구조(EC2 직접 노출)에서는 HTTPS를 위해 **ALB(Application Load Balancer)**가 필요합니다.
+> HTTPS가 당장 불필요하면 이 단계는 건너뛰어도 됩니다.
+> 나중에 프론트엔드 배포 시 HTTPS가 필수이므로, 그때 진행해도 됩니다.
+
+### 23.1 ACM 인증서 발급
+1. 상단 검색창 → `ACM` 입력 → **Certificate Manager** 클릭
+2. **인증서 요청** 버튼 클릭
+3. **퍼블릭 인증서 요청** 선택 → **다음**
+4. **도메인 이름**: `*.aegis-fire.com` 입력 (와일드카드)
+5. **다른 이름 추가**: `aegis-fire.com` (루트 도메인)
+6. **검증 방법**: `DNS 검증` 선택 (Route 53 사용 시 가장 간편)
+7. **요청** 버튼 클릭
+8. 인증서 목록에서 방금 생성한 인증서 클릭
+9. **Route 53에서 레코드 생성** 버튼 클릭 → **레코드 생성** 클릭
+10. **5~30분 대기** (상태: "검증 보류 중" → "발급됨")
+
+### 23.2 ALB 생성
+1. 상단 검색창 → `EC2` → 좌측 메뉴 **로드 밸런서** 클릭
+2. **로드 밸런서 생성** → **Application Load Balancer** 선택
+3. 설정:
+   - **이름**: `aegis-alb`
+   - **체계**: `인터넷 경계`
+   - **VPC**: `aegis-vpc`
+   - **서브넷**: 퍼블릭 서브넷 2개 선택
+   - **보안 그룹**: `aegis-ecs-sg` 선택
+4. **리스너**:
+   - HTTP:80 → HTTPS:443으로 리디렉션 (액션에서 설정)
+   - HTTPS:443 → 대상 그룹 (아래에서 생성)
+5. **인증서**: ACM에서 발급받은 인증서 선택
+6. **대상 그룹 생성**:
+   - **이름**: `aegis-backend-tg`
+   - **대상 유형**: `인스턴스`
+   - **포트**: `8080`
+   - **헬스체크 경로**: `/actuator/health`
+   - EC2 인스턴스를 대상으로 등록
+7. **로드 밸런서 생성** 클릭
+
+### 23.3 Route 53 레코드 수정
+1. Route 53 → 호스팅 영역 → 도메인 클릭
+2. 기존 `api` A 레코드 선택 → **레코드 편집**
+3. **별칭** 토글 켜기
+4. **트래픽 라우팅 대상**: `Application/Classic Load Balancer 에 대한 별칭`
+5. **리전**: `아시아 태평양(서울)`
+6. **로드 밸런서**: `aegis-alb` 선택
+7. **저장**
+
+HTTPS 적용 후 URL:
+
+| 용도 | URL |
+|------|-----|
+| **Swagger UI** | `https://api.aegis-fire.com/swagger-ui.html` |
+| **API 베이스** | `https://api.aegis-fire.com/api/` |
+
+> 포트 번호 없이 깔끔하게 접속 가능!
+
+---
+
 # 메모 정리
 
 ```
@@ -664,6 +1078,9 @@ RDS 비밀번호: ________________
 AWS 계정 ID (12자리): ________________
 ECR URI: ________________.dkr.ecr.ap-northeast-2.amazonaws.com/aegis/backend
 EC2 퍼블릭 IP: ________________
+Elastic IP: ________________
+등록 도메인: ________________
+API URL: api.________________
 IAM Access Key ID: AKIA________________
 IAM Secret Access Key: ________________
 ```

--- a/src/main/java/com/example/aegis_be/AegisBeApplication.java
+++ b/src/main/java/com/example/aegis_be/AegisBeApplication.java
@@ -3,10 +3,13 @@ package com.example.aegis_be;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class AegisBeApplication {
 
 	public static void main(String[] args) {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 		SpringApplication.run(AegisBeApplication.class, args);
 	}
 

--- a/src/main/java/com/example/aegis_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/aegis_be/domain/auth/controller/AuthController.java
@@ -1,0 +1,55 @@
+package com.example.aegis_be.domain.auth.controller;
+
+import com.example.aegis_be.domain.auth.dto.*;
+import com.example.aegis_be.domain.auth.service.AuthService;
+import com.example.aegis_be.global.common.ApiResponse;
+import com.example.aegis_be.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Auth", description = "인증 API")
+@Validated
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "소방서 검색", description = "소방서명 자동완성용 검색")
+    @GetMapping("/fire-stations/search")
+    public ApiResponse<List<FireStationSearchResponse>> searchFireStations(
+            @Parameter(description = "검색어", example = "마포") @RequestParam @NotBlank(message = "검색어는 필수입니다") String query) {
+        return ApiResponse.success(authService.searchFireStations(query));
+    }
+
+    @Operation(summary = "로그인", description = "소방서명과 비밀번호로 인증 후 토큰 발급")
+    @PostMapping("/login")
+    public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ApiResponse.success(authService.login(request));
+    }
+
+    @Operation(summary = "토큰 갱신", description = "리프레시 토큰으로 새 액세스 토큰 발급")
+    @PostMapping("/refresh")
+    public ApiResponse<TokenRefreshResponse> refresh(@Valid @RequestBody TokenRefreshRequest request) {
+        return ApiResponse.success(authService.refresh(request));
+    }
+
+    @Operation(summary = "로그아웃", description = "현재 세션 로그아웃 처리")
+    @PostMapping("/logout")
+    @PreAuthorize("hasRole('FIRE_STATION')")
+    public ApiResponse<Void> logout(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        authService.logout(userDetails.getName());
+        return ApiResponse.success();
+    }
+}

--- a/src/main/java/com/example/aegis_be/domain/auth/controller/DevController.java
+++ b/src/main/java/com/example/aegis_be/domain/auth/controller/DevController.java
@@ -1,0 +1,64 @@
+package com.example.aegis_be.domain.auth.controller;
+
+import com.example.aegis_be.domain.auth.dto.FireStationCreateRequest;
+import com.example.aegis_be.domain.auth.entity.FireStation;
+import com.example.aegis_be.domain.auth.repository.FireStationRepository;
+import com.example.aegis_be.global.common.ApiResponse;
+import com.example.aegis_be.global.error.BusinessException;
+import com.example.aegis_be.global.error.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Dev", description = "개발용 API")
+@Profile("!prod")
+@RestController
+@RequestMapping("/api/dev")
+@RequiredArgsConstructor
+public class DevController {
+
+    private final FireStationRepository fireStationRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Operation(summary = "소방서 계정 생성", description = "테스트용 소방서 계정 생성")
+    @PostMapping("/fire-stations")
+    public ApiResponse<Void> createFireStation(@Valid @RequestBody FireStationCreateRequest request) {
+        if (fireStationRepository.existsByName(request.getName())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NAME);
+        }
+
+        fireStationRepository.save(FireStation.builder()
+                .name(request.getName())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .build());
+
+        return ApiResponse.success();
+    }
+
+    @Operation(summary = "전체 소방서 목록 조회", description = "등록된 모든 소방서 목록 확인")
+    @GetMapping("/fire-stations")
+    public ApiResponse<List<FireStationListItem>> listFireStations() {
+        List<FireStationListItem> list = fireStationRepository.findAll().stream()
+                .map(fs -> new FireStationListItem(fs.getId(), fs.getName()))
+                .toList();
+        return ApiResponse.success(list);
+    }
+
+    @Operation(summary = "소방서 계정 삭제", description = "테스트 계정 삭제")
+    @DeleteMapping("/fire-stations/{id}")
+    public ApiResponse<Void> deleteFireStation(@PathVariable Long id) {
+        if (!fireStationRepository.existsById(id)) {
+            throw new BusinessException(ErrorCode.FIRE_STATION_NOT_FOUND);
+        }
+        fireStationRepository.deleteById(id);
+        return ApiResponse.success();
+    }
+
+    public record FireStationListItem(Long id, String name) {}
+}

--- a/src/main/java/com/example/aegis_be/domain/auth/dto/FireStationCreateRequest.java
+++ b/src/main/java/com/example/aegis_be/domain/auth/dto/FireStationCreateRequest.java
@@ -1,0 +1,16 @@
+package com.example.aegis_be.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FireStationCreateRequest {
+
+    @NotBlank(message = "소방서명은 필수입니다")
+    private String name;
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    private String password;
+}

--- a/src/main/java/com/example/aegis_be/domain/auth/dto/FireStationSearchResponse.java
+++ b/src/main/java/com/example/aegis_be/domain/auth/dto/FireStationSearchResponse.java
@@ -1,0 +1,20 @@
+package com.example.aegis_be.domain.auth.dto;
+
+import com.example.aegis_be.domain.auth.entity.FireStation;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FireStationSearchResponse {
+
+    private Long id;
+    private String name;
+
+    public static FireStationSearchResponse from(FireStation fireStation) {
+        return FireStationSearchResponse.builder()
+                .id(fireStation.getId())
+                .name(fireStation.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/example/aegis_be/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/example/aegis_be/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.example.aegis_be.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "소방서명은 필수입니다")
+    private String name;
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    private String password;
+}

--- a/src/main/java/com/example/aegis_be/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/example/aegis_be/domain/auth/dto/LoginResponse.java
@@ -1,0 +1,19 @@
+package com.example.aegis_be.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponse {
+
+    private String accessToken;
+    private String refreshToken;
+    private FireStationInfo fireStation;
+
+    @Getter
+    @Builder
+    public static class FireStationInfo {
+        private String name;
+    }
+}

--- a/src/main/java/com/example/aegis_be/domain/auth/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/example/aegis_be/domain/auth/dto/TokenRefreshRequest.java
@@ -1,0 +1,13 @@
+package com.example.aegis_be.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenRefreshRequest {
+
+    @NotBlank(message = "리프레시 토큰은 필수입니다")
+    private String refreshToken;
+}

--- a/src/main/java/com/example/aegis_be/domain/auth/dto/TokenRefreshResponse.java
+++ b/src/main/java/com/example/aegis_be/domain/auth/dto/TokenRefreshResponse.java
@@ -1,0 +1,11 @@
+package com.example.aegis_be.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenRefreshResponse {
+
+    private String accessToken;
+}

--- a/src/main/java/com/example/aegis_be/domain/auth/entity/FireStation.java
+++ b/src/main/java/com/example/aegis_be/domain/auth/entity/FireStation.java
@@ -1,0 +1,45 @@
+package com.example.aegis_be.domain.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "fire_station",
+        indexes = @Index(name = "idx_name", columnList = "name", unique = true))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FireStation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String name;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public FireStation(String name, String password) {
+        this.name = name;
+        this.password = password;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/aegis_be/domain/auth/repository/FireStationRepository.java
+++ b/src/main/java/com/example/aegis_be/domain/auth/repository/FireStationRepository.java
@@ -1,0 +1,16 @@
+package com.example.aegis_be.domain.auth.repository;
+
+import com.example.aegis_be.domain.auth.entity.FireStation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FireStationRepository extends JpaRepository<FireStation, Long> {
+
+    Optional<FireStation> findByName(String name);
+
+    List<FireStation> findByNameContaining(String name);
+
+    boolean existsByName(String name);
+}

--- a/src/main/java/com/example/aegis_be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/aegis_be/domain/auth/service/AuthService.java
@@ -1,0 +1,84 @@
+package com.example.aegis_be.domain.auth.service;
+
+import com.example.aegis_be.domain.auth.dto.*;
+import com.example.aegis_be.domain.auth.entity.FireStation;
+import com.example.aegis_be.domain.auth.repository.FireStationRepository;
+import com.example.aegis_be.global.error.BusinessException;
+import com.example.aegis_be.global.error.ErrorCode;
+import com.example.aegis_be.global.security.jwt.JwtTokenProvider;
+import com.example.aegis_be.global.security.jwt.TokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final FireStationRepository fireStationRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenService tokenService;
+
+    public LoginResponse login(LoginRequest request) {
+        FireStation fireStation = fireStationRepository
+                .findByName(request.getName())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_CREDENTIALS));
+
+        if (!passwordEncoder.matches(request.getPassword(), fireStation.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        String accessToken = jwtTokenProvider.createAccessToken(fireStation.getName());
+        String refreshToken = jwtTokenProvider.createRefreshToken(fireStation.getName());
+
+        tokenService.saveRefreshToken(fireStation.getName(), refreshToken);
+
+        log.info("Login successful: {}", fireStation.getName());
+
+        return LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .fireStation(LoginResponse.FireStationInfo.builder()
+                        .name(fireStation.getName())
+                        .build())
+                .build();
+    }
+
+    public TokenRefreshResponse refresh(TokenRefreshRequest request) {
+        String refreshToken = request.getRefreshToken();
+
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+
+        String name = jwtTokenProvider.getSubject(refreshToken);
+
+        if (!tokenService.validateRefreshToken(name, refreshToken)) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(name);
+
+        return TokenRefreshResponse.builder()
+                .accessToken(newAccessToken)
+                .build();
+    }
+
+    public void logout(String name) {
+        tokenService.deleteRefreshToken(name);
+        log.info("Logout successful: {}", name);
+    }
+
+    public List<FireStationSearchResponse> searchFireStations(String query) {
+        return fireStationRepository.findByNameContaining(query).stream()
+                .map(FireStationSearchResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/example/aegis_be/domain/dispatch/controller/DispatchController.java
+++ b/src/main/java/com/example/aegis_be/domain/dispatch/controller/DispatchController.java
@@ -1,0 +1,64 @@
+package com.example.aegis_be.domain.dispatch.controller;
+
+import com.example.aegis_be.domain.dispatch.dto.DispatchSessionCreateRequest;
+import com.example.aegis_be.domain.dispatch.dto.DispatchSessionResponse;
+import com.example.aegis_be.domain.dispatch.service.DispatchService;
+import com.example.aegis_be.global.common.ApiResponse;
+import com.example.aegis_be.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Dispatch", description = "출동 세션 API")
+@RestController
+@RequestMapping("/api/dispatch/sessions")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('FIRE_STATION')")
+public class DispatchController {
+
+    private final DispatchService dispatchService;
+
+    @Operation(summary = "출동 세션 생성", description = "대표자명을 입력하여 새 출동 세션을 시작. 날짜/시간은 자동 기록.")
+    @PostMapping
+    public ApiResponse<DispatchSessionResponse> createSession(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody DispatchSessionCreateRequest request) {
+        return ApiResponse.success(dispatchService.createSession(userDetails.getName(), request));
+    }
+
+    @Operation(summary = "출동 세션 조회", description = "세션 ID로 출동 세션 상세 정보 조회")
+    @GetMapping("/{sessionId}")
+    public ApiResponse<DispatchSessionResponse> getSession(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long sessionId) {
+        return ApiResponse.success(dispatchService.getSession(userDetails.getName(), sessionId));
+    }
+
+    @Operation(summary = "활성 세션 목록", description = "현재 출동 중인 세션 목록 조회. 혹시 몰라서 추가.")
+    @GetMapping("/active")
+    public ApiResponse<List<DispatchSessionResponse>> getActiveSessions(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.success(dispatchService.getActiveSessions(userDetails.getName()));
+    }
+
+    @Operation(summary = "전체 세션 목록", description = "모든 출동 세션 목록 조회 (완료 포함)")
+    @GetMapping
+    public ApiResponse<List<DispatchSessionResponse>> getAllSessions(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.success(dispatchService.getAllSessions(userDetails.getName()));
+    }
+
+    @Operation(summary = "출동 완료", description = "출동 세션을 완료 처리. 완료 시각이 자동 기록.")
+    @PatchMapping("/{sessionId}/complete")
+    public ApiResponse<DispatchSessionResponse> completeSession(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long sessionId) {
+        return ApiResponse.success(dispatchService.completeSession(userDetails.getName(), sessionId));
+    }
+}

--- a/src/main/java/com/example/aegis_be/domain/dispatch/dto/DispatchSessionCreateRequest.java
+++ b/src/main/java/com/example/aegis_be/domain/dispatch/dto/DispatchSessionCreateRequest.java
@@ -1,0 +1,15 @@
+package com.example.aegis_be.domain.dispatch.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DispatchSessionCreateRequest {
+
+    @Schema(description = "대표자명", example = "김응급")
+    @NotBlank(message = "대표자명은 필수입니다")
+    private String representativeName;
+}

--- a/src/main/java/com/example/aegis_be/domain/dispatch/dto/DispatchSessionResponse.java
+++ b/src/main/java/com/example/aegis_be/domain/dispatch/dto/DispatchSessionResponse.java
@@ -1,0 +1,31 @@
+package com.example.aegis_be.domain.dispatch.dto;
+
+import com.example.aegis_be.domain.dispatch.entity.DispatchSession;
+import com.example.aegis_be.domain.dispatch.entity.DispatchStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class DispatchSessionResponse {
+
+    private Long sessionId;
+    private String fireStationName;
+    private String representativeName;
+    private DispatchStatus status;
+    private LocalDateTime dispatchedAt;
+    private LocalDateTime completedAt;
+
+    public static DispatchSessionResponse from(DispatchSession session) {
+        return DispatchSessionResponse.builder()
+                .sessionId(session.getId())
+                .fireStationName(session.getFireStation().getName())
+                .representativeName(session.getRepresentativeName())
+                .status(session.getStatus())
+                .dispatchedAt(session.getDispatchedAt())
+                .completedAt(session.getCompletedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/aegis_be/domain/dispatch/entity/DispatchSession.java
+++ b/src/main/java/com/example/aegis_be/domain/dispatch/entity/DispatchSession.java
@@ -1,0 +1,59 @@
+package com.example.aegis_be.domain.dispatch.entity;
+
+import com.example.aegis_be.domain.auth.entity.FireStation;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "dispatch_session",
+        indexes = {
+                @Index(name = "idx_dispatch_fire_station", columnList = "fire_station_id"),
+                @Index(name = "idx_dispatch_status", columnList = "status")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DispatchSession {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fire_station_id", nullable = false)
+    private FireStation fireStation;
+
+    @Column(name = "representative_name", nullable = false, length = 30)
+    private String representativeName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DispatchStatus status;
+
+    @Column(name = "dispatched_at", nullable = false)
+    private LocalDateTime dispatchedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Builder
+    public DispatchSession(FireStation fireStation, String representativeName) {
+        this.fireStation = fireStation;
+        this.representativeName = representativeName;
+        this.status = DispatchStatus.ACTIVE;
+        this.dispatchedAt = LocalDateTime.now();
+    }
+
+    public void complete() {
+        this.status = DispatchStatus.COMPLETED;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    public boolean isActive() {
+        return this.status == DispatchStatus.ACTIVE;
+    }
+}

--- a/src/main/java/com/example/aegis_be/domain/dispatch/entity/DispatchStatus.java
+++ b/src/main/java/com/example/aegis_be/domain/dispatch/entity/DispatchStatus.java
@@ -1,0 +1,14 @@
+package com.example.aegis_be.domain.dispatch.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DispatchStatus {
+
+    ACTIVE("출동 중"),
+    COMPLETED("출동 완료");
+
+    private final String description;
+}

--- a/src/main/java/com/example/aegis_be/domain/dispatch/repository/DispatchSessionRepository.java
+++ b/src/main/java/com/example/aegis_be/domain/dispatch/repository/DispatchSessionRepository.java
@@ -1,0 +1,17 @@
+package com.example.aegis_be.domain.dispatch.repository;
+
+import com.example.aegis_be.domain.dispatch.entity.DispatchSession;
+import com.example.aegis_be.domain.dispatch.entity.DispatchStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DispatchSessionRepository extends JpaRepository<DispatchSession, Long> {
+
+    Optional<DispatchSession> findByIdAndFireStationId(Long id, Long fireStationId);
+
+    List<DispatchSession> findByFireStationIdAndStatusOrderByDispatchedAtDesc(Long fireStationId, DispatchStatus status);
+
+    List<DispatchSession> findByFireStationIdOrderByDispatchedAtDesc(Long fireStationId);
+}

--- a/src/main/java/com/example/aegis_be/domain/dispatch/service/DispatchService.java
+++ b/src/main/java/com/example/aegis_be/domain/dispatch/service/DispatchService.java
@@ -1,0 +1,94 @@
+package com.example.aegis_be.domain.dispatch.service;
+
+import com.example.aegis_be.domain.auth.entity.FireStation;
+import com.example.aegis_be.domain.auth.repository.FireStationRepository;
+import com.example.aegis_be.domain.dispatch.dto.DispatchSessionCreateRequest;
+import com.example.aegis_be.domain.dispatch.dto.DispatchSessionResponse;
+import com.example.aegis_be.domain.dispatch.entity.DispatchSession;
+import com.example.aegis_be.domain.dispatch.entity.DispatchStatus;
+import com.example.aegis_be.domain.dispatch.repository.DispatchSessionRepository;
+import com.example.aegis_be.global.error.BusinessException;
+import com.example.aegis_be.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DispatchService {
+
+    private final DispatchSessionRepository dispatchSessionRepository;
+    private final FireStationRepository fireStationRepository;
+
+    @Transactional
+    public DispatchSessionResponse createSession(String name, DispatchSessionCreateRequest request) {
+        FireStation fireStation = fireStationRepository.findByName(name)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FIRE_STATION_NOT_FOUND));
+
+        DispatchSession session = DispatchSession.builder()
+                .fireStation(fireStation)
+                .representativeName(request.getRepresentativeName())
+                .build();
+
+        dispatchSessionRepository.save(session);
+
+        log.info("Dispatch session created: sessionId={}, representative={}", session.getId(), request.getRepresentativeName());
+
+        return DispatchSessionResponse.from(session);
+    }
+
+    public DispatchSessionResponse getSession(String name, Long sessionId) {
+        FireStation fireStation = findFireStation(name);
+        DispatchSession session = findSessionByFireStation(sessionId, fireStation.getId());
+        return DispatchSessionResponse.from(session);
+    }
+
+    public List<DispatchSessionResponse> getActiveSessions(String name) {
+        FireStation fireStation = findFireStation(name);
+        return dispatchSessionRepository
+                .findByFireStationIdAndStatusOrderByDispatchedAtDesc(fireStation.getId(), DispatchStatus.ACTIVE)
+                .stream()
+                .map(DispatchSessionResponse::from)
+                .toList();
+    }
+
+    public List<DispatchSessionResponse> getAllSessions(String name) {
+        FireStation fireStation = findFireStation(name);
+        return dispatchSessionRepository
+                .findByFireStationIdOrderByDispatchedAtDesc(fireStation.getId())
+                .stream()
+                .map(DispatchSessionResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public DispatchSessionResponse completeSession(String name, Long sessionId) {
+        FireStation fireStation = findFireStation(name);
+        DispatchSession session = findSessionByFireStation(sessionId, fireStation.getId());
+
+        if (!session.isActive()) {
+            throw new BusinessException(ErrorCode.DISPATCH_SESSION_NOT_ACTIVE);
+        }
+
+        session.complete();
+
+        log.info("Dispatch session completed: sessionId={}", sessionId);
+
+        return DispatchSessionResponse.from(session);
+    }
+
+    private DispatchSession findSessionByFireStation(Long sessionId, Long fireStationId) {
+        return dispatchSessionRepository.findByIdAndFireStationId(sessionId, fireStationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DISPATCH_SESSION_NOT_FOUND));
+    }
+
+    private FireStation findFireStation(String name) {
+        return fireStationRepository.findByName(name)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FIRE_STATION_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/aegis_be/global/common/ApiResponse.java
+++ b/src/main/java/com/example/aegis_be/global/common/ApiResponse.java
@@ -1,0 +1,64 @@
+package com.example.aegis_be.global.common;
+
+import com.example.aegis_be.global.error.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final T data;
+    private final ErrorInfo error;
+
+    public static <T> ApiResponse<T> success(T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .data(data)
+                .build();
+    }
+
+    public static ApiResponse<Void> success() {
+        return ApiResponse.<Void>builder()
+                .success(true)
+                .build();
+    }
+
+    public static ApiResponse<Void> error(ErrorCode errorCode) {
+        return ApiResponse.<Void>builder()
+                .success(false)
+                .error(ErrorInfo.of(errorCode))
+                .build();
+    }
+
+    public static ApiResponse<Void> error(ErrorCode errorCode, String message) {
+        return ApiResponse.<Void>builder()
+                .success(false)
+                .error(ErrorInfo.of(errorCode, message))
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class ErrorInfo {
+        private final String code;
+        private final String message;
+
+        public static ErrorInfo of(ErrorCode errorCode) {
+            return ErrorInfo.builder()
+                    .code(errorCode.getCode())
+                    .message(errorCode.getMessage())
+                    .build();
+        }
+
+        public static ErrorInfo of(ErrorCode errorCode, String message) {
+            return ErrorInfo.builder()
+                    .code(errorCode.getCode())
+                    .message(message)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/aegis_be/global/config/CorsConfig.java
+++ b/src/main/java/com/example/aegis_be/global/config/CorsConfig.java
@@ -1,0 +1,33 @@
+package com.example.aegis_be.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigins;
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList(allowedOrigins.split(",")));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("Authorization"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/com/example/aegis_be/global/config/RedisConfig.java
+++ b/src/main/java/com/example/aegis_be/global/config/RedisConfig.java
@@ -1,0 +1,69 @@
+package com.example.aegis_be.global.config;
+
+import io.lettuce.core.cluster.ClusterClientOptions;
+import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.List;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Profile("prod")
+    @Bean
+    public RedisConnectionFactory redisClusterConnectionFactory() {
+        RedisClusterConfiguration clusterConfig = new RedisClusterConfiguration(
+                List.of(host + ":" + port));
+
+        ClusterTopologyRefreshOptions topologyRefreshOptions = ClusterTopologyRefreshOptions.builder()
+                .enablePeriodicRefresh(Duration.ofMinutes(10))
+                .enableAllAdaptiveRefreshTriggers()
+                .build();
+
+        ClusterClientOptions clientOptions = ClusterClientOptions.builder()
+                .topologyRefreshOptions(topologyRefreshOptions)
+                .build();
+
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+                .commandTimeout(Duration.ofSeconds(3))
+                .clientOptions(clientOptions)
+                .useSsl()
+                .build();
+
+        return new LettuceConnectionFactory(clusterConfig, clientConfig);
+    }
+
+    @Profile("!prod")
+    @Bean
+    public RedisConnectionFactory redisStandaloneConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/com/example/aegis_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/aegis_be/global/config/SecurityConfig.java
@@ -1,0 +1,59 @@
+package com.example.aegis_be.global.config;
+
+import com.example.aegis_be.global.security.JwtAuthenticationEntryPoint;
+import com.example.aegis_be.global.security.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final CorsConfigurationSource corsConfigurationSource;
+
+    private static final String[] PUBLIC_ENDPOINTS = {
+            "/api/auth/**",
+            "/api/dev/**",
+            "/actuator/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/v3/api-docs/**",
+            "/test/**"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception ->
+                        exception.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/aegis_be/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/aegis_be/global/config/SwaggerConfig.java
@@ -1,19 +1,31 @@
 package com.example.aegis_be.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
 
+    private static final String SECURITY_SCHEME_NAME = "Bearer Authentication";
+
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
                 .info(new Info()
                         .title("Aegis API")
-                        .description("Aegis Backend API Documentation")
-                        .version("v1.0.0"));
+                        .description("백엔드 API")
+                        .version("v1.0.0"))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+                                .name(SECURITY_SCHEME_NAME)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
     }
 }

--- a/src/main/java/com/example/aegis_be/global/error/BusinessException.java
+++ b/src/main/java/com/example/aegis_be/global/error/BusinessException.java
@@ -1,0 +1,19 @@
+package com.example.aegis_be.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/aegis_be/global/error/ErrorCode.java
+++ b/src/main/java/com/example/aegis_be/global/error/ErrorCode.java
@@ -1,0 +1,35 @@
+package com.example.aegis_be.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "서버 내부 오류가 발생했습니다"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C003", "허용되지 않은 HTTP 메서드입니다"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "C004", "요청한 리소스를 찾을 수 없습니다"),
+
+    // Auth
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 토큰입니다"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "만료된 토큰입니다"),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "A004", "소방서명 또는 비밀번호가 일치하지 않습니다"),
+    ALREADY_LOGGED_OUT(HttpStatus.UNAUTHORIZED, "A005", "이미 로그아웃된 사용자입니다"),
+
+    // FireStation
+    FIRE_STATION_NOT_FOUND(HttpStatus.NOT_FOUND, "F001", "소방서를 찾을 수 없습니다"),
+    DUPLICATE_NAME(HttpStatus.CONFLICT, "F002", "이미 존재하는 소방서명입니다"),
+
+    // Dispatch
+    DISPATCH_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "출동 세션을 찾을 수 없습니다"),
+    DISPATCH_SESSION_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "D002", "이미 종료된 출동 세션입니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/aegis_be/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/aegis_be/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,89 @@
+package com.example.aegis_be.global.error;
+
+import com.example.aegis_be.global.common.ApiResponse;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        log.warn("BusinessException: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.error(errorCode, e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e) {
+        log.warn("Validation failed: {}", e.getMessage());
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .orElse(ErrorCode.INVALID_INPUT_VALUE.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE, message));
+    }
+
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleBindException(BindException e) {
+        log.warn("Bind failed: {}", e.getMessage());
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .orElse(ErrorCode.INVALID_INPUT_VALUE.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE, message));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleConstraintViolationException(
+            ConstraintViolationException e) {
+        log.warn("Constraint violation: {}", e.getMessage());
+        String message = e.getConstraintViolations().stream()
+                .findFirst()
+                .map(violation -> violation.getMessage())
+                .orElse(ErrorCode.INVALID_INPUT_VALUE.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT_VALUE.getStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_INPUT_VALUE, message));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleHttpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException e) {
+        log.warn("Method not allowed: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.METHOD_NOT_ALLOWED.getStatus())
+                .body(ApiResponse.error(ErrorCode.METHOD_NOT_ALLOWED));
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleNoHandlerFoundException(NoHandlerFoundException e) {
+        log.warn("No handler found: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.RESOURCE_NOT_FOUND.getStatus())
+                .body(ApiResponse.error(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unexpected error occurred", e);
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/com/example/aegis_be/global/security/CustomUserDetails.java
+++ b/src/main/java/com/example/aegis_be/global/security/CustomUserDetails.java
@@ -1,0 +1,56 @@
+package com.example.aegis_be.global.security;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final String name;
+    private final String role;
+
+    public CustomUserDetails(String name, String role) {
+        this.name = name;
+        this.role = role;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role));
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return name;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/example/aegis_be/global/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/aegis_be/global/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package com.example.aegis_be.global.security;
+
+import com.example.aegis_be.global.common.ApiResponse;
+import com.example.aegis_be.global.error.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ApiResponse<Void> apiResponse = ApiResponse.error(ErrorCode.UNAUTHORIZED);
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+    }
+}

--- a/src/main/java/com/example/aegis_be/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/aegis_be/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,65 @@
+package com.example.aegis_be.global.security.jwt;
+
+import com.example.aegis_be.global.error.BusinessException;
+import com.example.aegis_be.global.security.CustomUserDetails;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenService tokenService;
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token)) {
+            try {
+                if (jwtTokenProvider.validateToken(token)) {
+                    String name = jwtTokenProvider.getSubject(token);
+
+                    if (tokenService.isLoggedIn(name)) {
+                        String role = jwtTokenProvider.getRole(token);
+                        CustomUserDetails userDetails = new CustomUserDetails(name, role);
+                        UsernamePasswordAuthenticationToken authentication =
+                                new UsernamePasswordAuthenticationToken(
+                                        userDetails, null, userDetails.getAuthorities());
+                        SecurityContextHolder.getContext().setAuthentication(authentication);
+                    }
+                }
+            } catch (BusinessException e) {
+                log.debug("Token validation failed: {}", e.getMessage());
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/aegis_be/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/aegis_be/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,7 +1,9 @@
 package com.example.aegis_be.global.security.jwt;
 
+import com.example.aegis_be.global.common.ApiResponse;
 import com.example.aegis_be.global.error.BusinessException;
 import com.example.aegis_be.global.security.CustomUserDetails;
+import tools.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,6 +25,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenService tokenService;
+    private final ObjectMapper objectMapper;
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
@@ -49,6 +52,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 }
             } catch (BusinessException e) {
                 log.debug("Token validation failed: {}", e.getMessage());
+                SecurityContextHolder.clearContext();
+                response.setStatus(e.getErrorCode().getStatus().value());
+                response.setContentType("application/json;charset=UTF-8");
+                response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.error(e.getErrorCode())));
+                return;
             }
         }
 

--- a/src/main/java/com/example/aegis_be/global/security/jwt/JwtProperties.java
+++ b/src/main/java/com/example/aegis_be/global/security/jwt/JwtProperties.java
@@ -1,0 +1,17 @@
+package com.example.aegis_be.global.security.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    private String secret;
+    private long accessTokenValidity;
+    private long refreshTokenValidity;
+}

--- a/src/main/java/com/example/aegis_be/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/aegis_be/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,89 @@
+package com.example.aegis_be.global.security.jwt;
+
+import com.example.aegis_be.global.error.BusinessException;
+import com.example.aegis_be.global.error.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtProperties jwtProperties;
+    private SecretKey secretKey;
+
+    private static final String CLAIM_ROLE = "role";
+    private static final String ROLE_FIRE_STATION = "FIRE_STATION";
+
+    @PostConstruct
+    protected void init() {
+        this.secretKey = Keys.hmacShaKeyFor(
+                jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String createAccessToken(String name) {
+        return createToken(name, jwtProperties.getAccessTokenValidity());
+    }
+
+    public String createRefreshToken(String name) {
+        return createToken(name, jwtProperties.getRefreshTokenValidity());
+    }
+
+    private String createToken(String subject, long validityInMillis) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMillis);
+
+        return Jwts.builder()
+                .subject(subject)
+                .claim(CLAIM_ROLE, ROLE_FIRE_STATION)
+                .issuedAt(now)
+                .expiration(validity)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String getSubject(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    public String getRole(String token) {
+        return parseClaims(token).get(CLAIM_ROLE, String.class);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.debug("Expired JWT token");
+            throw new BusinessException(ErrorCode.EXPIRED_TOKEN);
+        } catch (JwtException | IllegalArgumentException e) {
+            log.debug("Invalid JWT token");
+            return false;
+        }
+    }
+
+    public long getRefreshTokenValidity() {
+        return jwtProperties.getRefreshTokenValidity();
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/com/example/aegis_be/global/security/jwt/TokenService.java
+++ b/src/main/java/com/example/aegis_be/global/security/jwt/TokenService.java
@@ -1,0 +1,47 @@
+package com.example.aegis_be.global.security.jwt;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private static final String REFRESH_TOKEN_PREFIX = "RT:";
+
+    public void saveRefreshToken(String name, String refreshToken) {
+        String key = REFRESH_TOKEN_PREFIX + name;
+        long validityInSeconds = jwtTokenProvider.getRefreshTokenValidity() / 1000;
+        redisTemplate.opsForValue().set(key, refreshToken, validityInSeconds, TimeUnit.SECONDS);
+        log.debug("Saved refresh token for: {}", name);
+    }
+
+    public String getRefreshToken(String name) {
+        String key = REFRESH_TOKEN_PREFIX + name;
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public boolean validateRefreshToken(String name, String refreshToken) {
+        String storedToken = getRefreshToken(name);
+        return refreshToken.equals(storedToken);
+    }
+
+    public void deleteRefreshToken(String name) {
+        String key = REFRESH_TOKEN_PREFIX + name;
+        redisTemplate.delete(key);
+        log.debug("Deleted refresh token for: {}", name);
+    }
+
+    public boolean isLoggedIn(String name) {
+        String key = REFRESH_TOKEN_PREFIX + name;
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -4,7 +4,7 @@ spring:
 
   data:
     redis:
-      host: clustercfg.aegis-redis.irelkc.apn2.cache.amazonaws.com
-      port: 6379
+      host: ${SPRING_DATA_REDIS_HOST}
+      port: ${SPRING_DATA_REDIS_PORT:6379}
       ssl:
-        enabled: true
+        enabled: ${SPRING_DATA_REDIS_SSL:true}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,10 @@
+spring:
+  jpa:
+    show-sql: false
+
+  data:
+    redis:
+      host: clustercfg.aegis-redis.irelkc.apn2.cache.amazonaws.com
+      port: 6379
+      ssl:
+        enabled: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: aegis-backend
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:local}
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -8,14 +10,25 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
+  data:
+    redis:
+      host: ${SPRING_DATA_REDIS_HOST:localhost}
+      port: ${SPRING_DATA_REDIS_PORT:6379}
+
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
     properties:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+    open-in-view: false
+
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-validity: 3600000
+  refresh-token-validity: 1209600000
 
 management:
   endpoints:
@@ -25,3 +38,6 @@ management:
   endpoint:
     health:
       show-details: always
+
+cors:
+  allowed-origins: ${CORS_ORIGINS}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #1 

어떤 변경사항이 있었나요?
- [ ] 🐛 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [x] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [x] 📃 Docs Documentation writing and editing (README.md, Swagger, etc.)
- [x] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [x] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다.
- [x] commit convention을 지켰습니다.
- [x] Issue를 생성하고, Issue 번호에 맞는 브랜치를 생성했습니다.
- [x] Issue 컨벤션에 맞게 Issue를 생성했습니다.

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
- 로그인                                                                                                                                        소방서명(name)과 비밀번호(password)로 인증. 성공 시 access token과 refresh token을 발급하고, refresh token은 Redis에 저장.
                                                                                                                                                
- 토큰 갱신                                                 
  access token 만료 시 refresh token을 전송하면 Redis에 저장된 토큰과 대조 후 새 access token 발급.

- 로그아웃
  Redis에서 해당 소방서의 refresh token을 삭제하여 세션 무효화. 이후 해당 토큰으로는 인증 불가.

- 소방서 검색 (이름 자동완성용)
  소방서명 일부를 입력하면 이름에 포함된 소방서 목록을 반환. 로그인 화면에서 자동완성 용도.

- 세션 생성
  대표자명을 입력하여 출동 세션 시작. 출동 시각은 서버에서 자동 기록(KST). 로그인한 소방서에 귀속.

- 세션 상세 조회
  세션 ID로 특정 출동 세션의 상세 정보(대표자명, 상태, 출동/완료 시각) 조회. 본인 소방서 세션만 접근 가능.

- 활성 세션 목록 조회
  현재 출동 중(ACTIVE)인 세션만 필터링하여 최신순으로 반환.

- 전체 세션 목록 조회
  완료된 세션 포함 전체 목록을 최신순으로 반환.

- 출동 완료 (세션 종료 처리)
  활성 세션을 COMPLETED 상태로 변경. 완료 시각 자동 기록. 이미 완료된 세션이면 에러 반환.

- 개발용 소방서 계정 생성, 목록 조회, 삭제
  prod 환경 제외. 인증 없이 소방서 계정을 생성(name + password), 전체 목록 확인, ID로 삭제 가능. 테스트 용도.

- Redis 추가 (ElastiCache)
  로컬은 docker-compose로 Redis 컨테이너 실행, 운영은 AWS ElastiCache(SSL) 연결. refresh token 저장 및 로그인 상태 관리에 사용.

- JWT 및 Redis 기반 세션 관리
  access token은 stateless JWT로 매 요청마다 필터에서 검증. refresh token은 Redis에 저장하여 로그아웃 시 즉시 무효화. JWT subject에 소방서명을  
  담아 요청마다 소방서를 식별하고 데이터 격리.

- 초기 세팅
  Spring Boot 4.0.1 / Java 21 기반. MySQL 8.0, Redis 7, Swagger, CORS, Security 설정. JVM  타임존 Asia/Seoul 적용.


## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
N/A
